### PR TITLE
Removed 'Required' from Text, AuthorId, CommentId, and virtual Reply from Comment.cs

### DIFF
--- a/24Hour.Data/24Hour.Data.csproj
+++ b/24Hour.Data/24Hour.Data.csproj
@@ -84,7 +84,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Comment.cs" />
     <Compile Include="IdentityModels.cs" />
+    <Compile Include="Post.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Reply.cs" />
   </ItemGroup>

--- a/24Hour.Data/Comment.cs
+++ b/24Hour.Data/Comment.cs
@@ -13,14 +13,11 @@ namespace _24Hour.Data
         [Key]
         public int Id { get; set; }
 
-        [Required]
         public string Text { get; set; }
 
-        [Required]
         public Guid AuthorId { get; set; }
 
         [ForeignKey(nameof(Post))]
-        [Required]
         public int CommentId { get; set; }
         public virtual Reply Reply { get; set; }
 

--- a/24Hour.Data/Comment.cs
+++ b/24Hour.Data/Comment.cs
@@ -13,6 +13,7 @@ namespace _24Hour.Data
         [Key]
         public int Id { get; set; }
 
+        [Required]
         public string Text { get; set; }
 
         public Guid AuthorId { get; set; }


### PR DESCRIPTION
I've removed "Required" from the Text, AuthorId, CommentId, and Reply properties.  Does everyone agree with this before we merge my updated branch to 'develop2'?